### PR TITLE
Remove numpy>=1.19 dependency version spec

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ setup_requires =
     setuptools_scm
 
 install_requires =
-    numpy>=1.19
+    numpy
     astropy
 
 package_dir =
@@ -45,7 +45,6 @@ docs =
     stsci-rtd-theme
 
 [flake8]
-#select = F, W, E101, E111, E112, E113, E401, E402, E501, E711, E722
 select = F, W, E, C
 # We should set max line length to 88 eventually
 max-line-length = 110


### PR DESCRIPTION
This `numpy>=1.19` requirement is far ahead of requirements for either `astropy`, `jwst` or `romancal`, which currently specify `numpy>=1.17` as a minimum.